### PR TITLE
feat: create mock files for users and profiles

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,8 +1,12 @@
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View } from 'react-native';
 import { BotaoTeste } from './src/components/BotaoTeste';
+import { usuariosMock } from './src/mocks/usuariosMock';
+import { perfisMock } from './src/mocks/perfisMock';
 
 export default function App() {
+  console.log(usuariosMock);
+  console.log(perfisMock);
   return (
     <View style={styles.container}>
       <Text style={styles.title}>ShakeIT</Text>

--- a/src/components/__tests__/perfisMock.test.tsx
+++ b/src/components/__tests__/perfisMock.test.tsx
@@ -1,0 +1,17 @@
+import { usuariosMock } from "../../mocks/usuariosMock";
+import { perfisMock } from "../../mocks/perfisMock";
+
+describe("Ligação Perfil ↔ Usuario (Relacionamento)", () => {
+    it("deve recuperar corretamente nome e fotoUrl do Usuario a partir do idUsuario do Perfil", () => {
+        const perfil = perfisMock.find(p => p.idUsuario === 2);
+
+        expect(perfil).toBeDefined();
+
+        const usuario = usuariosMock.find(u => u.id === perfil!.idUsuario);
+
+        expect(usuario).toBeDefined();
+
+        expect(usuario!.nome).toBe("Maria da Silva");
+        expect(usuario!.fotoUrl).toBe("https://i.pravatar.cc/150?img=2");
+    });
+});

--- a/src/mocks/perfisMock.ts
+++ b/src/mocks/perfisMock.ts
@@ -1,0 +1,163 @@
+interface Medidas {
+    camisa: string;
+    calca: string;
+    calcado: string;
+};
+
+interface Preferencias {
+    coisasQueAmo: string[];
+    melhorEvitar: string[];
+};
+
+interface Perfil {
+    idUsuario: number;
+    isConfirmado: boolean;
+    medidas: Medidas;
+    preferencias: Preferencias;
+    isDependente: boolean;
+    idDependente?: number;
+};
+
+export const perfisMock: Perfil[] = [
+    {
+        idUsuario: 1,
+        isConfirmado: true,
+        medidas: {
+            camisa: "M",
+            calca: "40",
+            calcado: "40"
+        },
+        preferencias: {
+            coisasQueAmo: ["Administração"],
+            melhorEvitar: ["Desordem"]
+        },
+        isDependente: false, 
+    },
+    {
+        idUsuario: 2,
+        isConfirmado: true,
+        medidas: {
+            camisa: "P",
+            calca: "36",
+            calcado: "36"
+        },
+        preferencias: {
+            coisasQueAmo: ["Maquiagem", "Moda", "Perfumes"],
+            melhorEvitar: ["Roupas muito formais", "Chocolate amargo"]
+        },
+        isDependente: false
+    },
+    {
+        idUsuario: 3,
+        isConfirmado: true,
+        medidas: {
+            camisa: "M",
+            calca: "40",
+            calcado: "40"
+        },
+        preferencias: {
+            coisasQueAmo: ["Futebol", "Música"],
+            melhorEvitar: ["Livros"]
+        },
+        isDependente: false
+    },
+    {
+        idUsuario: 4,
+        isConfirmado: false,
+        medidas: {
+            camisa: "M",
+            calca: "38",
+            calcado: "37"
+        },
+        preferencias: {
+            coisasQueAmo: ["Skincare", "Velas aromáticas", "Séries"],
+            melhorEvitar: ["Produtos com cheiro forte", "Roupas apertadas"]
+        },
+        isDependente: false
+    },
+    {
+        idUsuario: 5,
+        isConfirmado: true,
+        medidas: {
+            camisa: "XGG",
+            calca: "XGG",
+            calcado: "33"
+        },
+        preferencias: {
+            coisasQueAmo: ["Comida", "Chocolate", "Comida, de novo"],
+            melhorEvitar: ["Fome"]
+        },
+        isDependente: false
+    },
+    {
+        idUsuario: 6,
+        isConfirmado: true,
+        medidas: {
+            camisa: "M",
+            calca: "38",
+            calcado: "37"
+        },
+        preferencias: {
+            coisasQueAmo: ["Decoração", "Plantas", "Chás"],
+            melhorEvitar: ["Objetos muito coloridos", "Café forte"]
+        },
+        isDependente: false
+    },
+    {
+        idUsuario: 7,
+        isConfirmado: true,
+        medidas: {
+            camisa: "10",
+            calca: "10",
+            calcado: "30"
+        },
+        preferencias: {
+            coisasQueAmo: ["Brinquedos", "Super-heróis", "Video game"],
+            melhorEvitar: ["Roupas formais", "Livros longos"]
+        },
+        isDependente: true,
+        idDependente: 6
+    },
+    {
+        idUsuario: 8,
+        isConfirmado: true,
+        medidas: {
+            camisa: "P",
+            calca: "36",
+            calcado: "35"
+        },
+        preferencias: {
+            coisasQueAmo: ["Academia", "Roupas fitness", "Saúde"],
+            melhorEvitar: ["Doces", "Fast food"]
+        },
+        isDependente: false
+    },
+    {
+        idUsuario: 9,
+        isConfirmado: false,
+        medidas: {
+            camisa: "G",
+            calca: "42",
+            calcado: "41"
+        },
+        preferencias: {
+            coisasQueAmo: ["Cerveja artesanal", "Churrasco", "Esportes"],
+            melhorEvitar: ["Doces", "Veganismo"]
+        },
+        isDependente: false
+    },
+    {
+        idUsuario: 10,
+        isConfirmado: false,
+        medidas: {
+            camisa: "M",
+            calca: "38",
+            calcado: "36"
+        },
+        preferencias: {
+            coisasQueAmo: ["Romance", "Chocolates", "Cinema"],
+            melhorEvitar: ["Filmes de terror", "Café"]
+        },
+        isDependente: false
+    }
+];

--- a/src/mocks/usuariosMock.ts
+++ b/src/mocks/usuariosMock.ts
@@ -1,0 +1,102 @@
+interface Usuario {
+    id: number;
+    email: string;
+    senha: string;
+    nome: string;
+    fotoUrl: string;
+    genero: string;
+    dataDeNascimento: string;
+};
+
+export const usuariosMock: Usuario[] = [
+    {
+        id: 1,
+        email: "admin@email.com",
+        senha: "12345",
+        nome: "Admin",
+        fotoUrl: "https://i.pravatar.cc/150?img=1",
+        genero: "Masculino",
+        dataDeNascimento: "1959-05-19"
+    },
+    {
+        id: 2,
+        email: "mariadasilva@email.com",
+        senha: "12345",
+        nome: "Maria da Silva",
+        fotoUrl: "https://i.pravatar.cc/150?img=2",
+        genero: "Feminino",
+        dataDeNascimento: "1995-05-10"
+    },
+    {
+        id: 3,
+        email: "joaodasilva@email.com",
+        senha: "12345",
+        nome: "João da Silva",
+        fotoUrl: "https://i.pravatar.cc/150?img=3",
+        genero: "Masculino",
+        dataDeNascimento: "1988-03-22"
+    },
+    {
+        id: 4,
+        email: "anasouza@email.com",
+        senha: "12345",
+        nome: "Ana Souza",
+        fotoUrl: "https://i.pravatar.cc/150?img=4",
+        genero: "Feminino",
+        dataDeNascimento: "2000-07-15"
+    },
+    {
+        id: 5,
+        email: "mariobeso@email.com",
+        senha: "12345",
+        nome: "Mario Beso",
+        fotoUrl: "https://i.pravatar.cc/150?img=5",
+        genero: "Masculino",
+        dataDeNascimento: "1992-11-30"
+    },
+    {
+        id: 6,
+        email: "laurajohnson@email.com",
+        senha: "12345",
+        nome: "Laura Johnson",
+        fotoUrl: "https://i.pravatar.cc/150?img=6",
+        genero: "Feminino",
+        dataDeNascimento: "1984-09-09"
+    },
+    {
+        id: 7,
+        email: "johnjohnson@email.com",
+        senha: "12345",
+        nome: "John Johnson",
+        fotoUrl: "https://i.pravatar.cc/150?img=7",
+        genero: "Masculino",
+        dataDeNascimento: "2015-12-16"
+    },
+    {
+        id: 8,
+        email: "julianarocha@email.com",
+        senha: "12345",
+        nome: "Juliana Rocha",
+        fotoUrl: "https://i.pravatar.cc/150?img=8",
+        genero: "Feminino",
+        dataDeNascimento: "1993-04-18"
+    },
+    {
+        id: 9,
+        email: "pedroalves@email.com",
+        senha: "12345",
+        nome: "Pedro Alves",
+        fotoUrl: "https://i.pravatar.cc/150?img=9",
+        genero: "Masculino",
+        dataDeNascimento: "1991-06-25"
+    },
+    {
+        id: 10,
+        email: "carlamendes@email.com",
+        senha: "12345",
+        nome: "Carla Mendes",
+        fotoUrl: "https://i.pravatar.cc/150?img=10",
+        genero: "Feminino",
+        dataDeNascimento: "1997-02-14"
+    },
+];


### PR DESCRIPTION
Observação: Acabei achando que fazer apenas um arquivo membersMock.ts com mocks de usuários e perfis ia ficar muito bagunçado, portanto criei dois arquivos separados para mocks de usuários e perfis. Ademais, se formos prosseguir com a criação de perfis customizados para parties diferentes, acho que essa separação vai deixar esse trabalho futuro mais fácil.