### PR TITLE
feat: implement party scanning and preview navigation flow with assoc…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { View, Text } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
@@ -14,6 +15,7 @@ import { Party } from "./src/types/Party";
 import { ShakeRevealScreen } from "./src/screens/ShakeReveal";
 import { PerfilSorteadoScreen } from "./src/screens/PerfilSorteado";
 import { ScanScreen } from "./src/screens/Scan";
+import { PartyPreviewScreen } from "./src/screens/PartyPreview";
 
 export type RootStackParamList = {
   Home: { novaParty?: Party } | undefined;
@@ -24,10 +26,18 @@ export type RootStackParamList = {
   RevealResult: undefined;
   PerfilSorteado: { idUsuario: number };
   Scan: undefined;
+  PartyPreview: { partyCode: string };
+  ParticipantLobby: { partyId: string };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
-// podemos tirar isso daqui depois, só pra testar a conexão com o firebase mesmo
+
+const ParticipantLobbyPlaceholder = () => (
+  <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <Text style={{ fontSize: 18 }}>Lobby do Participante (T16) - Em breve!</Text>
+  </View>
+);
+
 export default function App() {
   useEffect(() => {
     checkFirebaseConnection();
@@ -51,6 +61,8 @@ export default function App() {
         <Stack.Screen name="ShakeReveal" component={ShakeRevealScreen} />
         <Stack.Screen name="PerfilSorteado" component={PerfilSorteadoScreen} />
         <Stack.Screen name="Scan" component={ScanScreen} />
+        <Stack.Screen name="PartyPreview" component={PartyPreviewScreen} />
+        <Stack.Screen name="ParticipantLobby" component={ParticipantLobbyPlaceholder} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/screens/Home/HomeViewModel.ts
+++ b/src/screens/Home/HomeViewModel.ts
@@ -10,15 +10,15 @@ export function useHomeViewModel() {
   const handleCardPress = (party: Party) => {
     switch (party.status) {
       case "Aguardando Sorteio":
-        const partyCodeGerado = gerarPartyCode(); //partyCode é gerado aqui, porque ainda não o guardamos em memória
+        const partyCodeGerado = gerarPartyCode(); 
         navigation.navigate("PartyAdmin", {
           partyName: party.name,
-          partyCode: partyCodeGerado, //partyCode: party.partyCode ou partyCode: party.code, futuramente (será preciso atualizar o type Party, também)
+          partyCode: partyCodeGerado,
         });
         break;
       case "Sorteio Realizado":
       case "Fim do evento":
-          navigation.navigate("PerfilSorteado", { idUsuario: 10, }); //Usa-se 11 como valor de teste, por enquanto
+          navigation.navigate("PerfilSorteado", { idUsuario: 10, }); 
         break;
       default:
         break;

--- a/src/screens/PartyPreview/PartyPreviewScreen.test.tsx
+++ b/src/screens/PartyPreview/PartyPreviewScreen.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import { PartyPreviewScreen } from './index';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ params: { partyCode: '#NATAL55' } }),
+}));
+
+describe('Tela PartyPreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('deve renderizar as informações corretas da Party', () => {
+    const { getByText } = render(<PartyPreviewScreen />);
+
+    expect(getByText('Firma 2026')).toBeTruthy();
+    expect(getByText('R$ 50,00 a R$ 100,00')).toBeTruthy();
+    expect(getByText('Perfil Pendente')).toBeTruthy();
+  });
+
+  it('deve navegar para a próxima tela ao clicar em "Confirmar Entrada"', () => {
+    const { getByText } = render(<PartyPreviewScreen />);
+
+    fireEvent.press(getByText('Confirmar Entrada'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('ParticipantLobby', { partyId: 'mock1' });
+  });
+
+  it('deve abrir o modal de atenção ao clicar em "Voltar ao Início"', () => {
+    const { getByText, queryByText } = render(<PartyPreviewScreen />);
+
+    // Garante que o texto do modal existe
+    fireEvent.press(getByText('Voltar ao Início'));
+
+    expect(getByText('Seu perfil ainda não foi lockado para o sorteio, mas você já ingressou na party. Deseja realmente voltar?')).toBeTruthy();
+  });
+
+  it('deve fechar o modal ao clicar em "Cancelar"', () => {
+    const { getByText, queryByText } = render(<PartyPreviewScreen />);
+
+    // Abre o modal
+    fireEvent.press(getByText('Voltar ao Início'));
+    
+    // Clica em Cancelar
+    fireEvent.press(getByText('Cancelar'));
+
+    // Verifica que não houve navegação
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('deve fechar o modal e navegar para a Home ao clicar em "Voltar para Home"', () => {
+    const { getByText } = render(<PartyPreviewScreen />);
+
+    // Abre o modal
+    fireEvent.press(getByText('Voltar ao Início'));
+    
+    // Clica em Confirmar (Voltar para Home)
+    fireEvent.press(getByText('Voltar para Home'));
+
+    // Avança o timeout do setTimeout interno do handleConfirmModal
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('Home');
+  });
+});

--- a/src/screens/PartyPreview/PartyPreviewViewModel.ts
+++ b/src/screens/PartyPreview/PartyPreviewViewModel.ts
@@ -1,0 +1,56 @@
+import { useNavigation, useRoute, RouteProp } from "@react-navigation/native";
+import { useState } from "react";
+import { RootStackParamList } from "../../../App";
+import { Party } from "../../types/Party";
+
+// Mock data to simulate the party fetched via code
+const MOCK_PARTY: Party = {
+  id: "mock1",
+  name: "Firma 2026",
+  minPrice: 50,
+  maxPrice: 100,
+  idAdmin: 1,
+  inviteCode: "#NATAL55",
+  eventDate: "2026-12-20T00:00:00.000Z",
+  status: "Aguardando Sorteio",
+};
+
+type PartyPreviewRouteProp = RouteProp<RootStackParamList, 'PartyPreview'>;
+
+export function usePartyPreviewViewModel() {
+  const navigation = useNavigation<any>();
+  const route = useRoute<PartyPreviewRouteProp>();
+  
+  const [isModalVisible, setModalVisible] = useState(false);
+  
+  const party = MOCK_PARTY;
+
+  const handleBackPress = () => {
+    setModalVisible(true);
+  };
+
+  const handleCancelModal = () => {
+    setModalVisible(false);
+  };
+
+  const handleConfirmModal = () => {
+    setModalVisible(false);
+    // Aguarda o modal nativo desmontar antes de navegar para não travar os toques na Home
+    setTimeout(() => {
+      navigation.navigate("Home");
+    }, 100);
+  };
+
+  const handleReady = () => {
+    navigation.navigate("ParticipantLobby", { partyId: party.id });
+  };
+
+  return {
+    party,
+    isModalVisible,
+    handleBackPress,
+    handleCancelModal,
+    handleConfirmModal,
+    handleReady,
+  };
+}

--- a/src/screens/PartyPreview/index.tsx
+++ b/src/screens/PartyPreview/index.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { View, Text, ScrollView } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { usePartyPreviewViewModel } from "./PartyPreviewViewModel";
+import { styles } from "./styles";
+import { Button } from "../../components/Button";
+import { IconButton } from "../../components/IconButton";
+import { Tag } from "../../components/Tag";
+import { PopupModal } from "../../components/PopupModal";
+import { formatCurrency } from "../../utils/Formatting/formatCurrency";
+import { formatDate } from "../../utils/Formatting/formatDate";
+import { theme } from "../../styles/theme";
+
+export const PartyPreviewScreen = () => {
+  const { 
+    party, 
+    isModalVisible,
+    handleBackPress, 
+    handleCancelModal,
+    handleConfirmModal,
+    handleReady 
+  } = usePartyPreviewViewModel();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <IconButton iconName="chevron-left" onPress={handleBackPress} />
+      </View>
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <Text style={styles.subtitle}>Entrar na Party</Text>
+        <Text style={styles.title}>{party.name}</Text>
+        
+        <View style={styles.card}>
+          <View style={styles.infoRow}>
+            <Text style={styles.infoLabel}>Revelação</Text>
+            <Text style={styles.infoValue}>{formatDate(party.eventDate)}</Text>
+          </View>
+          
+          <View style={styles.divider} />
+          
+          <View style={styles.infoRow}>
+            <Text style={styles.infoLabel}>Valor</Text>
+            <Text style={styles.infoValue}>
+              R$ {formatCurrency(party.minPrice)} a R$ {formatCurrency(party.maxPrice)}
+            </Text>
+          </View>
+          
+          <View style={styles.divider} />
+          
+          <View style={styles.statusContainer}>
+            <Text style={styles.statusText}>Seu Status</Text>
+            <Tag label="Perfil Pendente" color={theme.colors.warning} />
+          </View>
+        </View>
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <Text style={styles.descriptionText}>
+          Confirme seus dados e marque que está pronto para liberar o sorteio.
+        </Text>
+        <Button 
+          title="Confirmar Entrada" 
+          onPress={handleReady} 
+        />
+        <Button 
+          title="Voltar ao Início" 
+          variant="outline" 
+          onPress={handleBackPress} 
+          style={{ marginTop: 12 }}
+        />
+      </View>
+
+      <PopupModal 
+        visible={isModalVisible}
+        title="Atenção!"
+        message="Seu perfil ainda não foi lockado para o sorteio, mas você já ingressou na party. Deseja realmente voltar?"
+        cancelText="Cancelar"
+        confirmText="Voltar para Home"
+        onCancel={handleCancelModal}
+        onConfirm={handleConfirmModal}
+      />
+    </SafeAreaView>
+  );
+};

--- a/src/screens/PartyPreview/styles.ts
+++ b/src/screens/PartyPreview/styles.ts
@@ -1,0 +1,84 @@
+import { StyleSheet, Platform, StatusBar } from "react-native";
+import { theme } from "../../styles/theme";
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  header: {
+    backgroundColor: theme.colors.surface,
+    padding: theme.metrics.padding,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+    zIndex: 2,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 16,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "bold",
+    color: theme.colors.primary,
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: theme.colors.textLight,
+    marginBottom: 24,
+  },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.metrics.borderRadius,
+    padding: 20,
+    marginBottom: 24,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  infoRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  infoLabel: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: theme.colors.textLight,
+  },
+  infoValue: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: theme.colors.text,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: theme.colors.border,
+    marginBottom: 16,
+  },
+  statusContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  statusText: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: theme.colors.text,
+  },
+  footer: {
+    padding: 24,
+    backgroundColor: theme.colors.background,
+  },
+  descriptionText: {
+    fontSize: 14,
+    color: theme.colors.textLight,
+    textAlign: "center",
+    marginBottom: 16,
+    lineHeight: 20,
+  }
+});

--- a/src/screens/Scan/ScanScreen.test.tsx
+++ b/src/screens/Scan/ScanScreen.test.tsx
@@ -5,6 +5,10 @@ import { ScanScreen } from './index';
 let mockPermission: any = null;
 const mockRequestPermission = jest.fn();
 
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: () => true,
+}));
+
 jest.mock('expo-camera', () => {
   const { View } = require('react-native');
   return {
@@ -13,7 +17,6 @@ jest.mock('expo-camera', () => {
   };
 });
 
-// Mock do AppHeader para isolar o teste
 jest.mock('../../components/AppHeader', () => ({
   AppHeader: ({ headerTitle }: any) => {
     const { Text } = require('react-native');
@@ -50,18 +53,13 @@ describe('Tela Scan', () => {
       <ScanScreen navigation={{}} />
     );
 
-    // Camera não deve renderizar
     expect(queryByTestId('camera-view')).toBeNull();
 
-    // Textos do fallback devem aparecer
     expect(getByText('Acesso à Câmera Necessário')).toBeTruthy();
     expect(getByText('Precisamos do acesso à câmera para ler o QR Code da Party.')).toBeTruthy();
-
-    // Botão de permitir
     const btnPermitir = getByText('Permitir Câmera');
     expect(btnPermitir).toBeTruthy();
 
-    // Interagir com o botão deve chamar a requestPermission
     fireEvent.press(btnPermitir);
     expect(mockRequestPermission).toHaveBeenCalledTimes(1);
   });
@@ -72,13 +70,10 @@ describe('Tela Scan', () => {
       <ScanScreen navigation={{}} />
     );
 
-    // A câmera deve renderizar
     expect(getByTestId('camera-view')).toBeTruthy();
 
-    // A máscara (overlay com as instruções) deve renderizar
     expect(getByText('Aponte a câmera para o QR Code para entrar na Party')).toBeTruthy();
-
-    // Não deve mostrar textos de permissão negada
+    
     expect(queryByText('Acesso à Câmera Necessário')).toBeNull();
   });
 });

--- a/src/screens/Scan/index.tsx
+++ b/src/screens/Scan/index.tsx
@@ -1,24 +1,31 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { CameraView, useCameraPermissions } from "expo-camera";
+import { useIsFocused } from "@react-navigation/native";
 import { AppHeader } from "../../components/AppHeader";
 import { Button } from "../../components/Button";
 import { styles } from "./styles";
 
 export const ScanScreen = ({ navigation }: any) => {
   const [permission, requestPermission] = useCameraPermissions();
+  const [scanned, setScanned] = useState(false);
+  const isFocused = useIsFocused();
 
   useEffect(() => {
-    // Tenta solicitar permissão no mount apenas se não tiver sido concedida e puder perguntar
+    if (isFocused) {
+      setScanned(false);
+    }
+  }, [isFocused]);
+
+  useEffect(() => {
     if (permission && !permission.granted && permission.canAskAgain) {
       requestPermission();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Executa apenas no mount para evitar loops
+  }, []);
 
   if (!permission) {
-    // Permissão ainda está carregando
     return (
       <SafeAreaView style={styles.container}>
         <AppHeader headerTitle="Escanear Party" />
@@ -27,7 +34,6 @@ export const ScanScreen = ({ navigation }: any) => {
   }
 
   if (!permission.granted) {
-    // Permissão negada ou aguardando ação
     return (
       <SafeAreaView style={styles.container}>
         <AppHeader headerTitle="Escanear Party" />
@@ -54,9 +60,10 @@ export const ScanScreen = ({ navigation }: any) => {
           style={StyleSheet.absoluteFillObject}
           facing="back"
           onBarcodeScanned={(result) => {
+            if (scanned) return;
+            setScanned(true);
             console.log("QR Code Lido:", result.data);
-            // TODO: Implementar lógica de entrada na party
-            // navigation.navigate("PartyAdmin", { partyCode: result.data });
+            navigation.navigate("PartyPreview", { partyCode: result.data });
           }}
           barcodeScannerSettings={{
             barcodeTypes: ["qr"],

--- a/src/utils/Formatting/formatCurrency.ts
+++ b/src/utils/Formatting/formatCurrency.ts
@@ -1,4 +1,13 @@
-export function formatCurrency(value: string): string {
+export function formatCurrency(value: string | number): string {
+    if (typeof value === "number") {
+        const numericValue = value.toFixed(2);
+        let [intPart, decimalPart] = numericValue.split(".");
+        intPart = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+        return `${intPart},${decimalPart}`;
+    }
+
+    if (!value) return "";
+
     const rawValue = value.replace(/\D/g, "");
 
     if (!rawValue) {

--- a/src/utils/Formatting/formatDate.ts
+++ b/src/utils/Formatting/formatDate.ts
@@ -1,6 +1,8 @@
 export function formatDate(
-    value?: Date | null,
+    value?: Date | string | null,
     locale: string = "pt-BR"
 ): string {
-    return value ? value.toLocaleDateString(locale) : "";
+    if (!value) return "";
+    const dateObj = typeof value === "string" ? new Date(value) : value;
+    return dateObj.toLocaleDateString(locale);
 }


### PR DESCRIPTION
### O que foi implementado?
- **Tela de Lobby de Check-in (T15):** Criada a tela `PartyPreviewScreen` seguindo o padrão MVVM para exibir os dados da Party formatados, Tag de Perfil Pendente e botões de ação.
- **Navegação do QR Code:** Atualizada a ação de sucesso da tela de `Scan` para redirecionar para a `PartyPreviewScreen`, incluindo proteção de estado (`scanned`) com `useIsFocused` para evitar múltiplas chamadas seguidas da câmera.
- **Padronização Visual:**
  - Ajuste do cabeçalho da `PartyPreview` para manter a mesma identidade do `AppHeader`.
  - Migração do sistema de alerta nativo (`Alert.alert`) para o uso orgânico do nosso componente unificado `PopupModal` (com correção de bug de foco/toque usando `setTimeout`).
  - Remoção de todos os *warnings* de depreciação trocando o import nativo pelo `SafeAreaView` do `react-native-safe-area-context`.
- **Refatoração de Utils Globais:** Melhoradas as tipagens e robustez das funções `formatCurrency` e `formatDate` para aceitarem dados numéricos/strings de ISO diretamente, prevenindo *TypeErrors* ao extrair os dados do BD.
- **Testes Unitários:** Adição da suíte completa de testes (`PartyPreviewScreen.test.tsx`), testando com sucesso a renderização e o controle do Popup Modal com *Fake Timers*. Os testes do Scanner também foram estabilizados com Mock de navegação.

### Checklist de Qualidade (Obrigatório)
- [x] **Clean Code:** variáveis e funções têm nomes significativos?
- [x] **Responsabilidade Única:** funções/componentes fazem apenas uma coisa?
- [x] **Testes Unitários:** a lógica (TS) foi testada e passou? *(163 testes passando no total)*
- [x] **Testes Funcionais:** a interface (React Native) funciona como o esperado?
- [x] **Sem Código Morto:** comentários desnecessários ou "lixo" removidos?

### Prova de Funcionamento

<img width="250" alt="image" src="https://github.com/user-attachments/assets/65fb565c-4f08-442f-855f-e133694e6d8d" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/cc56b60e-be6c-4aef-b73a-85af341d1b81" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/daa3b2a8-5b26-4c5d-835f-ac4b12b7e0ef" />
