### PR TITLE
Feature/T32

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,7 +35,7 @@ export type RootStackParamList = {
   Home: { novaParty?: Party } | undefined;
   CreateParty: undefined;
   PartyCreated: { party: Party };
-  PartyAdmin: { partyName: string; partyCode: string };
+  PartyAdmin: { partyId: string };
   PartyDrawRestrictions: { partyId: string };
   ShakeReveal: undefined;
   RevealResult: undefined;

--- a/src/dto/DrawRestriction/DrawRestrictionCreationDTO.ts
+++ b/src/dto/DrawRestriction/DrawRestrictionCreationDTO.ts
@@ -1,0 +1,8 @@
+import { RestrictionDirection } from "../../types/DrawRestriction";
+
+export interface DrawRestrictionCreationDTO {
+    party_id: string;
+    person_a_id: string;
+    person_b_id: string;
+    direction: RestrictionDirection;
+}

--- a/src/dto/DrawRestriction/DrawRestrictionResponseDTO.ts
+++ b/src/dto/DrawRestriction/DrawRestrictionResponseDTO.ts
@@ -1,0 +1,9 @@
+import { RestrictionDirection } from "../../types/DrawRestriction";
+
+export type DrawRestrictionResponseDTO = {
+    id: string;
+    party_id: string;
+    person_a_id: string;
+    person_b_id: string;
+    direction: RestrictionDirection;
+};

--- a/src/dto/Party/PartyCreationDTO.ts
+++ b/src/dto/Party/PartyCreationDTO.ts
@@ -1,0 +1,7 @@
+export interface PartyCreationDTO {
+    admin_id: string;
+    name: string;
+    event_date: string;
+    min_value: number;
+    max_value: number;
+}

--- a/src/screens/CreateParty/CreateParty.test.tsx
+++ b/src/screens/CreateParty/CreateParty.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import { CreatePartyScreen } from './index';
 import { createPartyInCloud } from '../../services/cloud/Party/PartyDb';
 import { useAuth } from '../../contexts/AuthContext/AuthContext';
@@ -23,8 +23,6 @@ jest.mock("firebase/firestore", () => ({
   getFirestore: jest.fn(),
   collection: jest.fn(),
 }));
-
-
 
 jest.mock('../../components/AppFooter', () => ({
   AppFooter: jest.fn(() => null),
@@ -57,8 +55,9 @@ jest.mock('../../components/IconButton', () => {
 });
 
 const mockUseAuth = useAuth as jest.Mock;
+const mockCreatePartyInCloud = createPartyInCloud as jest.Mock;
 
-(createPartyInCloud as unknown as jest.Mock).mockResolvedValue({
+const mockPartyResponse = {
   id: 'mockPartyId',
   name: 'Natal 2026',
   minPrice: 10,
@@ -67,7 +66,7 @@ const mockUseAuth = useAuth as jest.Mock;
   inviteCode: '#XYZ123',
   eventDate: '2026-12-25T00:00:00.000Z',
   status: 'Aguardando Sorteio',
-});
+};
 
 describe('Tela CreateParty', () => {
   beforeEach(() => {
@@ -79,8 +78,11 @@ describe('Tela CreateParty', () => {
         nome: 'Usuário Teste',
       },
     });
+
+    mockCreatePartyInCloud.mockResolvedValue(mockPartyResponse);
   });
-  it('deve validar os campos vazios, exibir erros vermelhos e não navegar', () => {
+
+  it('deve validar os campos vazios, exibir erros vermelhos e não navegar', async () => {
     const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
     const { getByText, getByPlaceholderText } = render(
       <CreatePartyScreen navigation={mockNavigation} />
@@ -88,7 +90,9 @@ describe('Tela CreateParty', () => {
 
     fireEvent.changeText(getByPlaceholderText('Ex: Amigo Secreto da Firma'), 'Natal 2026');
 
-    fireEvent.press(getByText('Criar Party'));
+    await act(async () => {
+      fireEvent.press(getByText('Criar Party'));
+    });
 
     expect(getByText('Selecione a data da revelação.')).toBeTruthy();
     expect(getByText('Preencha o valor mínimo e máximo.')).toBeTruthy();
@@ -102,24 +106,24 @@ describe('Tela CreateParty', () => {
     );
 
     fireEvent.changeText(getByPlaceholderText('Ex: Amigo Secreto da Firma'), 'Natal 2026');
-
     fireEvent.press(getByTestId('btn-selecionar-data'));
+    fireEvent.changeText(getByPlaceholderText('0,00'), '10,00'); 
+    fireEvent.changeText(getByPlaceholderText('50,00'), '50,00');
 
-    fireEvent.changeText(getByPlaceholderText('0,00'), '1000'); 
-    fireEvent.changeText(getByPlaceholderText('50,00'), '5000');
+    await act(async () => {
+      fireEvent.press(getByText('Criar Party'));
+    });
 
-    await fireEvent.press(getByText('Criar Party'));
+    expect(mockCreatePartyInCloud).toHaveBeenCalledWith({
+      name: 'Natal 2026',
+      event_date: '2026-12-25T00:00:00.000Z',
+      min_value: 10,
+      max_value: 50,
+      admin_id: 2, // ID vindo do mock do useAuth
+    });
 
     expect(mockNavigation.navigate).toHaveBeenCalledWith('PartyCreated', {
-      party: expect.objectContaining({
-        name: 'Natal 2026',
-        minPrice: 10,
-        maxPrice: 50,
-        idAdmin: 1,
-        inviteCode: '#XYZ123',
-        eventDate: '2026-12-25T00:00:00.000Z',
-        status: 'Aguardando Sorteio'
-      })
+      party: mockPartyResponse,
     });
   });
 
@@ -128,36 +132,25 @@ describe('Tela CreateParty', () => {
       usuarioAtual: null,
     });
 
-    const mockNavigation = {
-      navigate: jest.fn(),
-      goBack: jest.fn(),
-    };
-
+    const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
     const { getByText, getByPlaceholderText, getByTestId } = render(
       <CreatePartyScreen navigation={mockNavigation} />
     );
 
-    fireEvent.changeText(
-      getByPlaceholderText('Ex: Amigo Secreto da Firma'),
-      'Natal 2026'
-    );
-
+    fireEvent.changeText(getByPlaceholderText('Ex: Amigo Secreto da Firma'), 'Natal 2026');
     fireEvent.press(getByTestId('btn-selecionar-data'));
+    fireEvent.changeText(getByPlaceholderText('0,00'), '10,00');
+    fireEvent.changeText(getByPlaceholderText('50,00'), '50,00');
 
-    fireEvent.changeText(getByPlaceholderText('0,00'), '1000');
-
-    fireEvent.changeText(getByPlaceholderText('50,00'), '5000');
-
-    fireEvent.press(getByText('Criar Party'));
-
-    await waitFor(() => {
-      expect(createPartyInCloud).not.toHaveBeenCalled();
-
-      expect(mockNavigation.navigate).not.toHaveBeenCalled();
+    await act(async () => {
+      fireEvent.press(getByText('Criar Party'));
     });
+
+    expect(mockCreatePartyInCloud).not.toHaveBeenCalled();
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
   });
 
-  it('deve voltar à tela anterior ao confirmar a saída no modal', () => {
+  it('deve voltar à tela anterior ao confirmar a saída no modal', async () => {
     const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
     const { getByTestId, getByText, getByPlaceholderText } = render(
       <CreatePartyScreen navigation={mockNavigation} />
@@ -165,7 +158,10 @@ describe('Tela CreateParty', () => {
 
     fireEvent.changeText(getByPlaceholderText('Ex: Amigo Secreto da Firma'), 'Mudança');
     fireEvent.press(getByTestId('btn-chevron-left'));
-    fireEvent.press(getByText('Sair sem salvar'));
+    
+    await act(async () => {
+      fireEvent.press(getByText('Sair sem salvar'));
+    });
     
     expect(mockNavigation.goBack).toHaveBeenCalled();
   });
@@ -180,7 +176,7 @@ describe('Tela CreateParty', () => {
     expect(mockNavigation.goBack).toHaveBeenCalled();
   });
 
-  it('deve interceptar navegação do footer e exibir modal se houver alterações', () => {
+  it('deve interceptar navegação do footer e exibir modal se houver alterações', async () => {
     const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
     const { getByPlaceholderText, getByText } = render(
       <CreatePartyScreen navigation={mockNavigation} />
@@ -188,15 +184,17 @@ describe('Tela CreateParty', () => {
 
     fireEvent.changeText(getByPlaceholderText('Ex: Amigo Secreto da Firma'), 'Mudança');
     
-    // Disparar o onNavigateIntercept
     const calls = mockAppFooter.mock.calls;
     const testProps = calls[calls.length - 1][0];
+    
     act(() => {
       testProps.onNavigateIntercept('Home');
     });
 
-    // Confirmar saída
-    fireEvent.press(getByText('Sair sem salvar'));
+    await act(async () => {
+      fireEvent.press(getByText('Sair sem salvar'));
+    });
+
     expect(mockNavigation.navigate).toHaveBeenCalledWith('Home');
   });
 });

--- a/src/screens/CreateParty/CreatePartyViewModel.ts
+++ b/src/screens/CreateParty/CreatePartyViewModel.ts
@@ -1,8 +1,7 @@
 import { useState } from "react";
-import { Party } from "../../types/Party";
-import { gerarPartyCode } from "../../utils/PartyCode/gerarPartyCode";
 import { createPartyInCloud } from "../../services/cloud/Party/PartyDb";
 import { useAuth } from "../../contexts/AuthContext/AuthContext";
+import { PartyCreationDTO } from "../../dto/Party/PartyCreationDTO";
 
 export function useCreatePartyViewModel(navigation: any) {
   const [isModalVisible, setModalVisible] = useState(false);
@@ -97,22 +96,16 @@ export function useCreatePartyViewModel(navigation: any) {
 
     if (!isValid || !usuarioAtual) return;
 
-    const novaParty: Omit<Party, "id"> = {
+    const novaParty: PartyCreationDTO = {
       name: nomeParty,
       event_date: dataRevelacao!.toISOString(),
       min_value: numMin,
       max_value: numMax,
       admin_id: usuarioAtual.id,
-      invite_code: gerarPartyCode(),
-      status: "aguardando_sorteio",
-      block_dependent_draw: false,
-      allow_wishlist_changes_after_draw: false,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString()
     };
 
     try {
-    const createdParty = await createPartyInCloud(novaParty);
+      const createdParty = await createPartyInCloud(novaParty);
 
       console.log("Party criada no Firebase:", createdParty);
 

--- a/src/screens/Home/HomeViewModel.test.ts
+++ b/src/screens/Home/HomeViewModel.test.ts
@@ -1,7 +1,6 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { useHomeViewModel } from './HomeViewModel';
 import { useNavigation } from '@react-navigation/native';
-import { gerarPartyCode } from '../../utils/PartyCode/gerarPartyCode';
 import { partiesMock } from '../../mocks/partiesMock';
 
 jest.mock('@react-navigation/native', () => {
@@ -10,7 +9,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: jest.fn(),
   };
 });
-jest.mock('../../utils/PartyCode/gerarPartyCode');
+
 jest.mock('../../mocks/partiesMock', () => ({
   partiesMock: [
     { id: '1', name: 'Festa A', status: 'aguardando_sorteio' },
@@ -18,11 +17,13 @@ jest.mock('../../mocks/partiesMock', () => ({
     { id: '4', name: 'Festa D', status: 'Status Invalido' },
   ]
 }));
+
 jest.mock('../../mocks/participantesMock', () => ({
   participantesMock: [
     { usuario: { id: 'mock-user-uuid-1', nome: 'Duda' } }
   ]
 }));
+
 jest.mock('../../contexts/AuthContext/AuthContext', () => ({
   useAuth: jest.fn(() => ({
     usuarioAtual: { nome: 'Duda' },
@@ -35,7 +36,6 @@ describe('useHomeViewModel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useNavigation as jest.Mock).mockReturnValue({ navigate: mockNavigate });
-    (gerarPartyCode as jest.Mock).mockReturnValue('ABC-123');
   });
 
   it('deve retornar os dados iniciais corretamente (parties e userName)', () => {
@@ -55,7 +55,17 @@ describe('useHomeViewModel', () => {
     expect(mockNavigate).toHaveBeenCalledWith('CreateParty');
   });
 
-  it('deve gerar código e navegar para PartyAdmin quando status for "aguardando_sorteio"', () => {
+  it('deve navegar para Scan ao chamar handleScanPress', () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    act(() => {
+      result.current.handleScanPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('Scan');
+  });
+
+  it('deve navegar para PartyAdmin enviando o partyId quando status for "aguardando_sorteio"', () => {
     const { result } = renderHook(() => useHomeViewModel());
     const party = partiesMock[0];
 
@@ -63,10 +73,8 @@ describe('useHomeViewModel', () => {
       result.current.handleCardPress(party);
     });
 
-    expect(gerarPartyCode).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('PartyAdmin', {
-      partyName: party.name,
-      partyCode: 'ABC-123',
+      partyId: party.id,
     });
   });
 
@@ -78,7 +86,9 @@ describe('useHomeViewModel', () => {
       result.current.handleCardPress(party);
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith('PerfilSorteado', { idUsuario: 'mock-user-uuid-1' });
+    expect(mockNavigate).toHaveBeenCalledWith('PerfilSorteado', { 
+      idUsuario: 'mock-user-uuid-1' 
+    });
   });
 
   it('não deve navegar se o status for desconhecido (default)', () => {

--- a/src/screens/Home/HomeViewModel.ts
+++ b/src/screens/Home/HomeViewModel.ts
@@ -2,7 +2,6 @@ import { useNavigation } from "@react-navigation/native";
 import { partiesMock } from "../../mocks/partiesMock";
 import { participantesMock } from "../../mocks/participantesMock";
 import { Party } from "../../types/Party";
-import { gerarPartyCode } from "../../utils/PartyCode/gerarPartyCode";
 import { useAuth } from "../../contexts/AuthContext/AuthContext";
 
 export function useHomeViewModel() {
@@ -13,10 +12,8 @@ export function useHomeViewModel() {
   const handleCardPress = (party: Party) => {
     switch (party.status) {
       case "aguardando_sorteio":
-        const partyCodeGerado = gerarPartyCode();
         navigation.navigate("PartyAdmin", {
-          partyName: party.name,
-          partyCode: partyCodeGerado,
+          partyId: party.id,
         });
         break;
       case "sorteio_realizado":

--- a/src/screens/PartyAdmin/PartyAdminViewModel.test.ts
+++ b/src/screens/PartyAdmin/PartyAdminViewModel.test.ts
@@ -1,7 +1,8 @@
-import { renderHook, act } from '@testing-library/react-native';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { usePartyAdminViewModel } from './PartyAdminViewModel';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { participantesMock } from "../../mocks/participantesMock";
+import { getPartyFromCloud } from '../../services/cloud/Party/PartyDb';
 
 jest.mock('@react-navigation/native', () => {
   return {
@@ -9,6 +10,10 @@ jest.mock('@react-navigation/native', () => {
     useRoute: jest.fn(),
   };
 });
+
+jest.mock('../../services/cloud/Party/PartyDb', () => ({
+  getPartyFromCloud: jest.fn(),
+}));
 
 jest.mock('../../mocks/participantesMock', () => ({
   participantesMock: [
@@ -18,26 +23,51 @@ jest.mock('../../mocks/participantesMock', () => ({
   ]
 }));
 
+const mockGetPartyFromCloud = getPartyFromCloud as jest.Mock;
+
 describe('usePartyAdminViewModel', () => {
   const mockNavigate = jest.fn();
   const mockRouteParams = {
     params: {
-      partyName: 'Festa de Teste',
-      partyCode: 'XYZ123',
+      partyId: 'mock-party-123',
     },
+  };
+
+  const mockPartyResponse = {
+    id: 'mock-party-123',
+    name: 'Festa do Firestore',
+    invite_code: 'XYZ123',
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useNavigation as jest.Mock).mockReturnValue({ navigate: mockNavigate });
     (useRoute as jest.Mock).mockReturnValue(mockRouteParams);
+    
+    mockGetPartyFromCloud.mockResolvedValue(mockPartyResponse);
   });
 
-  it('deve extrair corretamente os parâmetros da rota', () => {
+  it('deve buscar e expor corretamente os dados da party obtidos do Firestore', async () => {
     const { result } = renderHook(() => usePartyAdminViewModel());
 
-    expect(result.current.partyName).toBe('Festa de Teste');
-    expect(result.current.partyCode).toBe('XYZ123');
+    expect(result.current.partyName).toBe('Carregando...');
+    expect(result.current.partyCode).toBe('...');
+
+    await waitFor(() => {
+      expect(mockGetPartyFromCloud).toHaveBeenCalledWith('mock-party-123');
+      expect(result.current.partyName).toBe('Festa do Firestore');
+      expect(result.current.partyCode).toBe('XYZ123');
+    });
+  });
+
+  it('deve manter o fallback de carregamento se o banco retornar null', async () => {
+    mockGetPartyFromCloud.mockResolvedValue(null);
+    const { result } = renderHook(() => usePartyAdminViewModel());
+
+    await waitFor(() => {
+      expect(result.current.partyName).toBe('Carregando...');
+      expect(result.current.partyCode).toBe('...');
+    });
   });
 
   it('deve retornar o título fixo do header', () => {
@@ -51,6 +81,18 @@ describe('usePartyAdminViewModel', () => {
     expect(result.current.confirmadosCount).toBe(2);
     expect(result.current.participantesTotal).toBe(3);
     expect(result.current.participantes).toEqual(participantesMock);
+  });
+
+  it('deve navegar para a tela "PartyDrawRestrictions" enviando o partyId', () => {
+    const { result } = renderHook(() => usePartyAdminViewModel());
+
+    act(() => {
+      result.current.handleNavigatePartyDrawRestrictions();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('PartyDrawRestrictions', { 
+      partyId: 'mock-party-123' 
+    });
   });
 
   it('deve navegar para a tela "ShakeReveal" ao chamar handleSorteioPress', () => {

--- a/src/screens/PartyAdmin/PartyAdminViewModel.ts
+++ b/src/screens/PartyAdmin/PartyAdminViewModel.ts
@@ -1,22 +1,48 @@
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { participantesMock } from "../../mocks/participantesMock";
+import { getPartyFromCloud } from '../../services/cloud/Party/PartyDb';
+import { useEffect, useState } from 'react';
+import { Party } from '../../types/Party';
+
+type RouteParams = {
+  partyId: string;
+};
 
 export function usePartyAdminViewModel() {
     const route = useRoute();
     const navigation = useNavigation<any>();
 
-    const { partyName, partyCode } = route.params as {
-        partyName: string;
-        partyCode: string;
-    };
+    const { partyId } = route.params as RouteParams;
 
+    const [party, setParty] = useState<Party | null>(null);
     const participantes = participantesMock;
     const confirmadosCount = participantes.filter(p => p.perfil.status === 'confirmado').length;
     const participantesTotal = participantes.length;
     const headerTitle = "Painel do Evento";
 
+    useEffect(() => {
+        async function fetchParty() {
+            try {
+                const cloudParty = await getPartyFromCloud(partyId);
+                if (cloudParty) {
+                    setParty(cloudParty);
+                } else {
+                    console.warn(`Festa com o ID ${partyId} não foi encontrada no banco.`);
+                }
+            } catch (error) {
+                console.error("Erro ao buscar a festa no Firestore:", error);
+            }
+        }
+        if (partyId) {
+            fetchParty();
+        }
+    }, [partyId]);
+
+    const partyName = party?.name ?? "Carregando...";
+    const partyCode = party?.invite_code ?? "...";
+
     const handleNavigatePartyDrawRestrictions = () => {
-        navigation.navigate("PartyDrawRestrictions", { partyId: "" })
+        navigation.navigate("PartyDrawRestrictions", { partyId: partyId })
     }
 
     const handleSorteioPress = () => {

--- a/src/screens/PartyDrawRestrictions/PartyDrawRestrictions.test.tsx
+++ b/src/screens/PartyDrawRestrictions/PartyDrawRestrictions.test.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, TouchableOpacity } from "react-native";
 import { render, fireEvent } from "@testing-library/react-native";
 import { PartyDrawRestrictionsScreen } from "./index";
 import { usePartyDrawRestrictionsViewModel } from "./PartyDrawRestrictionsViewModel";
 
+// 1. Declare all mock variables here (prefixed with 'Mock')
 const MockView = View;
 const MockText = Text;
+const MockTouchableOpacity = TouchableOpacity;
 
 jest.mock("./PartyDrawRestrictionsViewModel");
 const mockUsePartyDrawRestrictionsViewModel = usePartyDrawRestrictionsViewModel as jest.Mock;
@@ -16,7 +18,6 @@ jest.mock("@expo/vector-icons", () => ({
 
 jest.mock("../../components/AppHeader", () => {
   const actual = jest.requireActual("../../components/AppHeader");
-
   return {
     ...actual,
     AppHeader: ({ headerTitle }: { headerTitle: string }) => (
@@ -26,6 +27,17 @@ jest.mock("../../components/AppHeader", () => {
     ),
   };
 });
+
+// 2. Update this mock to use the allowed 'Mock' prefixed variables
+jest.mock("../../components/RestrictionCard", () => ({
+  RestrictionCard: ({ personAName, personBName, onPress }: any) => (
+    <MockView>
+      <MockText>{personAName}</MockText>
+      <MockText>{personBName}</MockText>
+      <MockTouchableOpacity testID="btn-delete-restriction" onPress={onPress} />
+    </MockView>
+  ),
+}));
 
 describe("PartyDrawRestrictionsScreen", () => {
   const defaultViewModelMock = {
@@ -43,7 +55,7 @@ describe("PartyDrawRestrictionsScreen", () => {
     RestrictionDirectionButtonTitle: "Não pode tirar",
     handleCreateRestriction: jest.fn(),
     handleDeleteRestriction: jest.fn(),
-    blockDependentDraw: true,
+    blockDependentDraw: false,
     BlockDependentDrawButtonTitle: "Impedir que Titulares e seus Dependentes se tirem",
     handleToggleBlockDependentDraw: jest.fn(),
   };
@@ -92,10 +104,10 @@ describe("PartyDrawRestrictionsScreen", () => {
     expect(defaultViewModelMock.handleToggleBlockDependentDraw).toHaveBeenCalledTimes(1);
   });
 
-  it("deve exibir o aviso se blockDependentDraw for false", () => {
+  it("deve exibir o aviso se blockDependentDraw for true", () => {
     mockUsePartyDrawRestrictionsViewModel.mockReturnValue({
       ...defaultViewModelMock,
-      blockDependentDraw: false,
+      blockDependentDraw: true,
     });
 
     const { getByText } = render(<PartyDrawRestrictionsScreen />);
@@ -110,7 +122,6 @@ describe("PartyDrawRestrictionsScreen", () => {
         personAName: "Alice",
         personBName: "Bob",
         restrictionDirection: "one_way",
-        onPress: jest.fn(),
       },
     ];
 
@@ -119,9 +130,14 @@ describe("PartyDrawRestrictionsScreen", () => {
       restrictionsList: mockList,
     });
 
-    const { getByText } = render(<PartyDrawRestrictionsScreen />);
+    const { getByText, getByTestId } = render(<PartyDrawRestrictionsScreen />);
 
     expect(getByText("Alice")).toBeTruthy();
     expect(getByText("Bob")).toBeTruthy();
+
+    const deleteButton = getByTestId("btn-delete-restriction");
+    fireEvent.press(deleteButton);
+
+    expect(defaultViewModelMock.handleDeleteRestriction).toHaveBeenCalledWith("id-regra-1");
   });
 });

--- a/src/screens/PartyDrawRestrictions/PartyDrawRestrictionsViewModel.test.ts
+++ b/src/screens/PartyDrawRestrictions/PartyDrawRestrictionsViewModel.test.ts
@@ -1,18 +1,25 @@
-import { renderHook, act } from '@testing-library/react-native';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { usePartyDrawRestrictionsViewModel } from "./PartyDrawRestrictionsViewModel";
+import { getPartyFromCloud, updatePartyDependentDrawFlagInCloud } from "../../services/cloud/Party/PartyDb";
+import { getDrawRestrictionsByPartyFromCloud, createDrawRestrictionInCloud, deleteDrawRestrictionFromCloud } from "../../services/cloud/DrawRestriction/DrawRestrictionDb";
 
 const mockPartyId = "party-123";
+
 jest.mock("@react-navigation/native", () => ({
   useRoute: () => ({
     params: { partyId: mockPartyId },
   }),
 }));
 
-jest.mock("../../mocks/partiesMock", () => ({
-  partiesMock: [
-    { id: "party-123", block_dependent_draw: true },
-    { id: "party-456", block_dependent_draw: false },
-  ],
+jest.mock("../../services/cloud/Party/PartyDb", () => ({
+  getPartyFromCloud: jest.fn(),
+  updatePartyDependentDrawFlagInCloud: jest.fn(),
+}));
+
+jest.mock("../../services/cloud/DrawRestriction/DrawRestrictionDb", () => ({
+  getDrawRestrictionsByPartyFromCloud: jest.fn(),
+  createDrawRestrictionInCloud: jest.fn(),
+  deleteDrawRestrictionFromCloud: jest.fn(),
 }));
 
 jest.mock("../../mocks/participantesMock", () => ({
@@ -22,12 +29,39 @@ jest.mock("../../mocks/participantesMock", () => ({
   ],
 }));
 
+const mockGetPartyFromCloud = getPartyFromCloud as jest.Mock;
+const mockUpdatePartyDependentDrawFlagInCloud = updatePartyDependentDrawFlagInCloud as jest.Mock;
+const mockGetDrawRestrictionsByPartyFromCloud = getDrawRestrictionsByPartyFromCloud as jest.Mock;
+const mockCreateDrawRestrictionInCloud = createDrawRestrictionInCloud as jest.Mock;
+const mockDeleteDrawRestrictionFromCloud = deleteDrawRestrictionFromCloud as jest.Mock;
+
 describe("usePartyDrawRestrictionsViewModel", () => {
+  const mockPartyResponse = {
+    id: "party-123",
+    name: "Festa de Teste",
+    block_dependent_draw: true,
+  };
+
+  const mockCloudRestrictions = [
+    {
+      id: "restriction-cloud-id",
+      party_id: "party-123",
+      person_a_id: "user-1",
+      person_b_id: "user-2",
+      direction: "one_way",
+    }
+  ];
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetPartyFromCloud.mockResolvedValue(mockPartyResponse);
+    mockGetDrawRestrictionsByPartyFromCloud.mockResolvedValue(mockCloudRestrictions);
+    mockCreateDrawRestrictionInCloud.mockResolvedValue("new-generated-id");
+    mockDeleteDrawRestrictionFromCloud.mockResolvedValue(undefined);
+    mockUpdatePartyDependentDrawFlagInCloud.mockResolvedValue(undefined);
   });
 
-  it("deve inicializar com os estados corretos baseados nos mocks", () => {
+  it("deve inicializar com os estados corretos e carregar dados assíncronos da nuvem", async () => {
     const { result } = renderHook(() => usePartyDrawRestrictionsViewModel());
 
     expect(result.current.participantsOptions).toEqual([
@@ -37,20 +71,28 @@ describe("usePartyDrawRestrictionsViewModel", () => {
 
     expect(result.current.personA).toBe("");
     expect(result.current.personB).toBe("");
-    expect(result.current.restrictionsList).toEqual([]);
     expect(result.current.restrictionDirection).toBe("one_way");
-    expect(result.current.blockDependentDraw).toBe(true);
     expect(result.current.RestrictionDirectionButtonTitle).toBe("Não pode tirar");
-    expect(result.current.BlockDependentDrawButtonTitle).toBe(
-      "Impedir que Titulares e seus Dependentes se tirem"
-    );
+
+    await waitFor(() => {
+      expect(mockGetPartyFromCloud).toHaveBeenCalledWith(mockPartyId);
+      expect(mockGetDrawRestrictionsByPartyFromCloud).toHaveBeenCalledWith(mockPartyId);
+      expect(result.current.blockDependentDraw).toBe(true);
+      expect(result.current.BlockDependentDrawButtonTitle).toBe("Permitir que Titulares e seus Dependentes se tirem");
+      expect(result.current.restrictionsList).toHaveLength(1);
+      expect(result.current.restrictionsList[0]).toMatchObject({
+        id: "restriction-cloud-id",
+        personAName: "Alice",
+        personBName: "Bob",
+        restrictionDirection: "one_way",
+      });
+    });
   });
 
-  it("deve alternar a direção da restrição (one_way / both_ways)", () => {
+  it("deve alternar a direção da restrição (one_way / both_ways)", async () => {
     const { result } = renderHook(() => usePartyDrawRestrictionsViewModel());
 
     expect(result.current.restrictionDirection).toBe("one_way");
-    expect(result.current.RestrictionDirectionButtonTitle).toBe("Não pode tirar");
 
     act(() => {
       result.current.handleChangeRestrictionDirection();
@@ -60,33 +102,32 @@ describe("usePartyDrawRestrictionsViewModel", () => {
     expect(result.current.RestrictionDirectionButtonTitle).toBe("Não podem se tirar");
   });
 
-  it("deve alternar o bloqueio de sorteio de dependentes", () => {
+  it("deve alternar o bloqueio de sorteio de dependentes e salvar no banco", async () => {
     const { result } = renderHook(() => usePartyDrawRestrictionsViewModel());
 
-    expect(result.current.blockDependentDraw).toBe(true);
+    await waitFor(() => expect(result.current.blockDependentDraw).toBe(true));
 
-    act(() => {
-      result.current.handleToggleBlockDependentDraw();
+    await act(async () => {
+      await result.current.handleToggleBlockDependentDraw();
     });
 
+    expect(mockUpdatePartyDependentDrawFlagInCloud).toHaveBeenCalledWith(mockPartyId, false);
     expect(result.current.blockDependentDraw).toBe(false);
-    expect(result.current.BlockDependentDrawButtonTitle).toBe(
-      "Permitir que Titulares e seus Dependentes se tirem"
-    );
+    expect(result.current.BlockDependentDrawButtonTitle).toBe("Impedir que Titulares e seus Dependentes se tirem");
   });
 
   describe("handleCreateRestriction", () => {
-    it("não deve criar restrição se personA ou personB estiverem vazios", () => {
+    it("não deve criar restrição se personA ou personB estiverem vazios", async () => {
       const { result } = renderHook(() => usePartyDrawRestrictionsViewModel());
 
-      act(() => {
-        result.current.handleCreateRestriction();
+      await act(async () => {
+        await result.current.handleCreateRestriction();
       });
 
-      expect(result.current.restrictionsList).toHaveLength(0);
+      expect(mockCreateDrawRestrictionInCloud).not.toHaveBeenCalled();
     });
 
-    it("não deve criar restrição se personA for igual a personB", () => {
+    it("não deve criar restrição se personA for igual a personB", async () => {
       const { result } = renderHook(() => usePartyDrawRestrictionsViewModel());
 
       act(() => {
@@ -94,14 +135,14 @@ describe("usePartyDrawRestrictionsViewModel", () => {
         result.current.setPersonB("user-1");
       });
 
-      act(() => {
-        result.current.handleCreateRestriction();
+      await act(async () => {
+        await result.current.handleCreateRestriction();
       });
 
-      expect(result.current.restrictionsList).toHaveLength(0);
+      expect(mockCreateDrawRestrictionInCloud).not.toHaveBeenCalled();
     });
 
-    it("deve criar uma restrição válida e limpar os inputs de seleção", () => {
+    it("deve criar uma restrição válida na nuvem e limpar os inputs de seleção", async () => {
       const { result } = renderHook(() => usePartyDrawRestrictionsViewModel());
 
       act(() => {
@@ -109,29 +150,37 @@ describe("usePartyDrawRestrictionsViewModel", () => {
         result.current.setPersonB("user-2");
       });
 
-      act(() => {
-        result.current.handleCreateRestriction();
+      await act(async () => {
+        await result.current.handleCreateRestriction();
       });
 
-      expect(result.current.restrictionsList).toHaveLength(1);
-      expect(result.current.restrictionsList[0]).toMatchObject({
-        personAName: "Alice",
-        personBName: "Bob",
-        restrictionDirection: "one_way",
+      expect(mockCreateDrawRestrictionInCloud).toHaveBeenCalledWith({
+        party_id: mockPartyId,
+        person_a_id: "user-1",
+        person_b_id: "user-2",
+        direction: "one_way",
       });
 
-      expect(result.current.personA).toBe("");
-      expect(result.current.personB).toBe("");
+      await waitFor(() => {
+        expect(result.current.personA).toBe("");
+        expect(result.current.personB).toBe("");
+        expect(result.current.restrictionsList).toHaveLength(2); 
+      });
     });
   });
 
-  it("deve chamar handleDeleteRestriction sem quebrar (mesmo que não implementado ainda)", () => {
-    const { result } = renderHook(() => usePartyDrawRestrictionsViewModel());
+  describe("handleDeleteRestriction", () => {
+    it("deve deletar uma restrição da nuvem e removê-la da listagem local do estado", async () => {
+      const { result } = renderHook(() => usePartyDrawRestrictionsViewModel());
 
-    expect(() => {
-      act(() => {
-        result.current.handleDeleteRestriction("algum-id");
+      await waitFor(() => expect(result.current.restrictionsList).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.handleDeleteRestriction("restriction-cloud-id");
       });
-    }).not.toThrow();
+
+      expect(mockDeleteDrawRestrictionFromCloud).toHaveBeenCalledWith("restriction-cloud-id");
+      expect(result.current.restrictionsList).toHaveLength(0);
+    });
   });
 });

--- a/src/screens/PartyDrawRestrictions/PartyDrawRestrictionsViewModel.ts
+++ b/src/screens/PartyDrawRestrictions/PartyDrawRestrictionsViewModel.ts
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRoute } from "@react-navigation/native";
 import { Participante } from "../../types/Participante";
-import { DrawRestriction, RestrictionDirection } from "../../types/DrawRestriction";
+import { RestrictionDirection } from "../../types/DrawRestriction";
 import { Party } from "../../types/Party";
-import { partiesMock } from "../../mocks/partiesMock";
 import { participantesMock } from "../../mocks/participantesMock";
+import { getPartyFromCloud, updatePartyDependentDrawFlagInCloud} from "../../services/cloud/Party/PartyDb";
+import { getDrawRestrictionsByPartyFromCloud, createDrawRestrictionInCloud, deleteDrawRestrictionFromCloud } from "../../services/cloud/DrawRestriction/DrawRestrictionDb";
+import { DrawRestrictionCreationDTO } from "../../dto/DrawRestriction/DrawRestrictionCreationDTO";
 
 type RouteParams = {
   partyId: string;
@@ -36,14 +38,26 @@ export function usePartyDrawRestrictionsViewModel() {
   const [restrictionDirection, setRestrictionDirection] = useState<RestrictionDirection>("one_way");
   const [blockDependentDraw, setBlockDependentDraw] = useState(true);
 
-  useEffect(() => { //Tirar isto daqui durante a T32
-    const foundParty = partiesMock.find(
-      (party) => party.id === partyId
-    );
-    setParty(foundParty ?? null);
+  useEffect(() => {
+    async function fetchParty() {
+      try {
+        const cloudParty = await getPartyFromCloud(partyId);
+        if (cloudParty) {
+          setParty(cloudParty);
+        } else {
+          console.warn(`Festa com o ID ${partyId} não foi encontrada no banco.`);
+        }
+      } catch (error) {
+        console.error("Erro ao buscar a festa no Firestore:", error);
+      }
+    }
+
+    if (partyId) {
+      fetchParty();
+    }
   }, [partyId]);
 
-  useEffect(() => { //Tirar isto daqui durante a T32
+  useEffect(() => { //Tirar isso daqui quando tivermos participantes no banco de dados
     const partyParticipants = participantesMock;
     setParticipants(partyParticipants);
   }, [partyId]);
@@ -66,47 +80,84 @@ export function usePartyDrawRestrictionsViewModel() {
     return map;
   }, [participants]);
 
+  useEffect(() => {
+    async function fetchRestrictions() {
+      if (!partyId || participants.length === 0) return;
+
+      try {
+        const cloudRestrictions = await getDrawRestrictionsByPartyFromCloud(partyId);
+        
+        const formattedRestrictions = cloudRestrictions.map((restriction) => {
+          const participantA = participantsMap.get(restriction.person_a_id);
+          const participantB = participantsMap.get(restriction.person_b_id);
+
+          return {
+            id: restriction.id,
+            personAName: participantA?.perfil.participant_name || "Desconhecido",
+            personBName: participantB?.perfil.participant_name || "Desconhecido",
+            restrictionDirection: restriction.direction,
+            onPress: () => handleDeleteRestriction(restriction.id),
+          };
+        });
+
+        setRestrictionsList(formattedRestrictions);
+      } catch (error) {
+        console.error("Erro ao carregar restrições da nuvem:", error);
+      }
+    }
+
+    fetchRestrictions();
+  }, [partyId, participants, participantsMap]);
+
   function handleChangeRestrictionDirection() {
     setRestrictionDirection((prev) =>
       prev === "one_way" ? "both_ways" : "one_way"
     );
   }
 
-  function handleCreateRestriction() {
+  async function handleCreateRestriction() {
     if (!personA || !personB) return;
     if (personA === personB) return;
 
-    const newRestriction: DrawRestriction = {
-      id: String(Date.now()), //Tirar isto daqui durante a T32
-      party_id: partyId,
-      person_a_id: personA,
-      person_b_id: personB,
-      direction: restrictionDirection,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    };
+    try {
+      const restrictionData: DrawRestrictionCreationDTO = {
+        party_id: partyId,
+        person_a_id: personA,
+        person_b_id: personB,
+        direction: restrictionDirection,
+      };
 
-    const participantA = participantsMap.get(personA);
-    const participantB = participantsMap.get(personB);
+      const generatedId = await createDrawRestrictionInCloud(restrictionData);
 
-    if (!participantA || !participantB) return;
+      const participantA = participantsMap.get(personA);
+      const participantB = participantsMap.get(personB);
 
-    const newRestrictionListElement: restrictionsListProps = {
-      id: newRestriction.id,
-      personAName: participantA.perfil.participant_name,
-      personBName: participantB.perfil.participant_name,
-      restrictionDirection: newRestriction.direction,
-      onPress: () => handleDeleteRestriction(newRestriction.id),
-    };
+      if (!participantA || !participantB) return;
 
-    setRestrictionsList((prev) => [...prev, newRestrictionListElement]);
+      const newRestrictionListElement: restrictionsListProps = {
+        id: generatedId,
+        personAName: participantA.perfil.participant_name,
+        personBName: participantB.perfil.participant_name,
+        restrictionDirection: restrictionDirection,
+        onPress: () => handleDeleteRestriction(generatedId),
+      };
 
-    setPersonA("");
-    setPersonB("");
+      setRestrictionsList((prev) => [...prev, newRestrictionListElement]);
+
+      setPersonA("");
+      setPersonB("");
+    } catch (error) {
+      console.error("Erro ao salvar restrição manual:", error);
+    }
   }
 
-  function handleDeleteRestriction(RestrictionId: string) {
-    //Deverá ser implementado durante a T32, com uma função de deletar restrição do banco de dados
+  async function handleDeleteRestriction(RestrictionId: string) {
+    try {
+      await deleteDrawRestrictionFromCloud(RestrictionId);
+      setRestrictionsList((prev) => prev.filter((item) => item.id !== RestrictionId));
+    } catch (error) {
+      console.error("Erro ao deletar restrição na nuvem:", error);
+    }
   }
 
   useEffect(() => {
@@ -115,24 +166,31 @@ export function usePartyDrawRestrictionsViewModel() {
     }
   }, [party]);
 
-  function handleToggleBlockDependentDraw() {
-    setBlockDependentDraw((prev) => !prev);
-    
+  async function handleToggleBlockDependentDraw() {
+  const newValue = !blockDependentDraw;
+
+  try {
+    await updatePartyDependentDrawFlagInCloud(partyId, newValue);
+
+    setBlockDependentDraw(newValue);
     setParty((prev) => {
       if (!prev) return prev;
-
       return {
         ...prev,
-        block_dependent_draw: !prev.block_dependent_draw,
+        block_dependent_draw: newValue,
       };
     });
+  } catch (error) {
+    console.error("Erro ao atualizar a flag global de dependentes na nuvem:", error);
   }
+}
 
   const RestrictionDirectionButtonTitle =
     restrictionDirection === "one_way" ? "Não pode tirar" : "Não podem se tirar";
 
-  const BlockDependentDrawButtonTitle =
-    blockDependentDraw ? "Impedir que Titulares e seus Dependentes se tirem" : "Permitir que Titulares e seus Dependentes se tirem";
+  const BlockDependentDrawButtonTitle = blockDependentDraw
+  ? "Permitir que Titulares e seus Dependentes se tirem"
+  : "Impedir que Titulares e seus Dependentes se tirem";
 
   return {
     participantsOptions,

--- a/src/screens/PartyDrawRestrictions/index.tsx
+++ b/src/screens/PartyDrawRestrictions/index.tsx
@@ -81,7 +81,7 @@ export const PartyDrawRestrictionsScreen = () => {
             </View>
             <View>
                 <Text style={styles.heading}>Regras Ativas</Text>
-                {!blockDependentDraw && (
+                {blockDependentDraw && (
                     <View style={styles.activeBlockDependentDraw}>
                         <Text>Titulares e dependentes não podem se tirar</Text>
                     </View>

--- a/src/services/cloud/DrawRestriction/DrawRestrictionDb.test.ts
+++ b/src/services/cloud/DrawRestriction/DrawRestrictionDb.test.ts
@@ -51,7 +51,7 @@ describe("DrawRestrictionDb Service", () => {
                         party_id: mockPartyId,
                         person_a_id: "user-a",
                         person_b_id: "user-b",
-                        direction: "unidirectional",
+                        direction: "one_way",
                     }),
                 },
                 {
@@ -60,7 +60,7 @@ describe("DrawRestrictionDb Service", () => {
                         party_id: mockPartyId,
                         person_a_id: "user-c",
                         person_b_id: "user-d",
-                        direction: "bidirectional",
+                        direction: "both_ways",
                     }),
                 }
             ];
@@ -84,14 +84,14 @@ describe("DrawRestrictionDb Service", () => {
                     party_id: mockPartyId,
                     person_a_id: "user-a",
                     person_b_id: "user-b",
-                    direction: "unidirectional",
+                    direction: "one_way",
                 },
                 {
                     id: "restriction-2",
                     party_id: mockPartyId,
                     person_a_id: "user-c",
                     person_b_id: "user-d",
-                    direction: "bidirectional",
+                    direction: "both_ways",
                 },
             ]);
         });
@@ -113,7 +113,7 @@ describe("DrawRestrictionDb Service", () => {
             party_id: "party-123",
             person_a_id: "user-a",
             person_b_id: "user-b",
-            direction: "unidirectional",
+            direction: "one_way",
         };
 
         it("deve criar uma restrição, atualizar com o ID gerado e retornar o ID com sucesso", async () => {

--- a/src/services/cloud/DrawRestriction/DrawRestrictionDb.test.ts
+++ b/src/services/cloud/DrawRestriction/DrawRestrictionDb.test.ts
@@ -1,0 +1,171 @@
+import { 
+    collection, 
+    addDoc, 
+    doc, 
+    updateDoc, 
+    deleteDoc, 
+    query, 
+    where, 
+    getDocs 
+} from "firebase/firestore";
+import { 
+    getDrawRestrictionsByPartyFromCloud, 
+    createDrawRestrictionInCloud, 
+    deleteDrawRestrictionFromCloud 
+} from "./DrawRestrictionDb";
+import { DrawRestrictionCreationDTO } from "../../../dto/DrawRestriction/DrawRestrictionCreationDTO";
+
+jest.mock("firebase/firestore", () => ({
+    collection: jest.fn(),
+    addDoc: jest.fn(),
+    doc: jest.fn(),
+    updateDoc: jest.fn(),
+    deleteDoc: jest.fn(),
+    query: jest.fn(),
+    where: jest.fn(),
+    getDocs: jest.fn(),
+    serverTimestamp: jest.fn(() => "mocked-timestamp"),
+}));
+
+jest.mock("../../../config/firebase", () => ({
+    db: {},
+}));
+
+describe("DrawRestrictionDb Service", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("getDrawRestrictionsByPartyFromCloud", () => {
+        it("deve retornar a lista de restrições de sorteio de uma party com sucesso", async () => {
+            const mockPartyId = "party-123";
+            
+            (collection as jest.Mock).mockReturnValue("mock-collection-ref");
+            (where as jest.Mock).mockReturnValue("mock-where-clause");
+            (query as jest.Mock).mockReturnValue("mock-query-ref");
+
+            const mockDocs = [
+                {
+                    id: "restriction-1",
+                    data: () => ({
+                        party_id: mockPartyId,
+                        person_a_id: "user-a",
+                        person_b_id: "user-b",
+                        direction: "unidirectional",
+                    }),
+                },
+                {
+                    id: "restriction-2",
+                    data: () => ({
+                        party_id: mockPartyId,
+                        person_a_id: "user-c",
+                        person_b_id: "user-d",
+                        direction: "bidirectional",
+                    }),
+                }
+            ];
+
+            const mockQuerySnapshot = {
+                forEach: (callback: Function) => mockDocs.forEach((doc) => callback(doc)),
+            };
+
+            (getDocs as jest.Mock).mockResolvedValueOnce(mockQuerySnapshot);
+
+            const result = await getDrawRestrictionsByPartyFromCloud(mockPartyId);
+
+            expect(collection).toHaveBeenCalledWith(expect.any(Object), "DRAW_RESTRICTION");
+            expect(where).toHaveBeenCalledWith("party_id", "==", mockPartyId);
+            expect(query).toHaveBeenCalledWith("mock-collection-ref", "mock-where-clause");
+            expect(getDocs).toHaveBeenCalledWith("mock-query-ref");
+
+            expect(result).toEqual([
+                {
+                    id: "restriction-1",
+                    party_id: mockPartyId,
+                    person_a_id: "user-a",
+                    person_b_id: "user-b",
+                    direction: "unidirectional",
+                },
+                {
+                    id: "restriction-2",
+                    party_id: mockPartyId,
+                    person_a_id: "user-c",
+                    person_b_id: "user-d",
+                    direction: "bidirectional",
+                },
+            ]);
+        });
+
+        it("deve retornar um array vazio se nenhuma restrição for encontrada", async () => {
+            const mockQuerySnapshot = {
+                forEach: (callback: Function) => {}, // Nenhuma iteração
+            };
+            (getDocs as jest.Mock).mockResolvedValueOnce(mockQuerySnapshot);
+
+            const result = await getDrawRestrictionsByPartyFromCloud("party-sem-restricoes");
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe("createDrawRestrictionInCloud", () => {
+        const mockDto: DrawRestrictionCreationDTO = {
+            party_id: "party-123",
+            person_a_id: "user-a",
+            person_b_id: "user-b",
+            direction: "unidirectional",
+        };
+
+        it("deve criar uma restrição, atualizar com o ID gerado e retornar o ID com sucesso", async () => {
+            const mockDocId = "new-restriction-id";
+            const mockDocRef = { id: mockDocId };
+
+            (collection as jest.Mock).mockReturnValue("mock-collection-ref");
+            (addDoc as jest.Mock).mockResolvedValueOnce(mockDocRef);
+            (doc as jest.Mock).mockReturnValue("mock-doc-ref");
+            (updateDoc as jest.Mock).mockResolvedValueOnce(undefined);
+
+            const result = await createDrawRestrictionInCloud(mockDto);
+
+            expect(collection).toHaveBeenCalledWith(expect.any(Object), "DRAW_RESTRICTION");
+            expect(addDoc).toHaveBeenCalledWith("mock-collection-ref", {
+                party_id: mockDto.party_id,
+                person_a_id: mockDto.person_a_id,
+                person_b_id: mockDto.person_b_id,
+                direction: mockDto.direction,
+                created_at: "mocked-timestamp",
+                updated_at: "mocked-timestamp",
+            });
+            expect(doc).toHaveBeenCalledWith(expect.any(Object), "DRAW_RESTRICTION", mockDocId);
+            expect(updateDoc).toHaveBeenCalledWith("mock-doc-ref", { id: mockDocId });
+            
+            expect(result).toBe(mockDocId);
+        });
+
+        it("deve propagar o erro caso o addDoc falhe", async () => {
+            (addDoc as jest.Mock).mockRejectedValueOnce(new Error("Erro no Firestore"));
+
+            await expect(createDrawRestrictionInCloud(mockDto)).rejects.toThrow("Erro no Firestore");
+            expect(updateDoc).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("deleteDrawRestrictionFromCloud", () => {
+        it("deve deletar a restrição com sucesso", async () => {
+            const restrictionId = "restriction-to-delete";
+            (doc as jest.Mock).mockReturnValue("mock-doc-ref");
+            (deleteDoc as jest.Mock).mockResolvedValueOnce(undefined);
+
+            await deleteDrawRestrictionFromCloud(restrictionId);
+
+            expect(doc).toHaveBeenCalledWith(expect.any(Object), "DRAW_RESTRICTION", restrictionId);
+            expect(deleteDoc).toHaveBeenCalledWith("mock-doc-ref");
+        });
+
+        it("deve propagar o erro caso o deleteDoc falhe", async () => {
+            (deleteDoc as jest.Mock).mockRejectedValueOnce(new Error("Erro ao deletar"));
+
+            await expect(deleteDrawRestrictionFromCloud("any-id")).rejects.toThrow("Erro ao deletar");
+        });
+    });
+});

--- a/src/services/cloud/DrawRestriction/DrawRestrictionDb.ts
+++ b/src/services/cloud/DrawRestriction/DrawRestrictionDb.ts
@@ -1,0 +1,61 @@
+import {
+    collection,
+    addDoc,
+    serverTimestamp,
+    doc,
+    updateDoc,
+    deleteDoc,
+    query,
+    where,
+    getDocs,
+} from "firebase/firestore";
+import { db } from '../../../config/firebase';
+import { DrawRestrictionCreationDTO } from "../../../dto/DrawRestriction/DrawRestrictionCreationDTO";
+import { DrawRestrictionResponseDTO } from "../../../dto/DrawRestriction/DrawRestrictionResponseDTO";
+
+export async function getDrawRestrictionsByPartyFromCloud(partyId: string): Promise<DrawRestrictionResponseDTO[]> {
+    const restrictionRef = collection(db, "DRAW_RESTRICTION");
+    const q = query(restrictionRef, where("party_id", "==", partyId));
+    
+    const querySnapshot = await getDocs(q);
+    const restrictions: DrawRestrictionResponseDTO[] = [];
+    
+    querySnapshot.forEach((doc) => {
+        const data = doc.data();
+        restrictions.push({
+            id: doc.id,
+            party_id: data.party_id,
+            person_a_id: data.person_a_id,
+            person_b_id: data.person_b_id,
+            direction: data.direction,
+        });
+    });
+    
+    return restrictions;
+}
+
+export async function createDrawRestrictionInCloud(dto: DrawRestrictionCreationDTO): Promise<string> {
+    const restrictionRef = collection(db, "DRAW_RESTRICTION");
+
+    const payload = {
+        party_id: dto.party_id,
+        person_a_id: dto.person_a_id,
+        person_b_id: dto.person_b_id,
+        direction: dto.direction,
+        created_at: serverTimestamp(),
+        updated_at: serverTimestamp(),
+    };
+
+    const docRef = await addDoc(restrictionRef, payload);
+
+    await updateDoc(doc(db, "DRAW_RESTRICTION", docRef.id), {
+        id: docRef.id,
+    });
+
+    return docRef.id;
+}
+
+export async function deleteDrawRestrictionFromCloud(restrictionId: string): Promise<void> {
+    const restrictionRef = doc(db, "DRAW_RESTRICTION", restrictionId);
+    await deleteDoc(restrictionRef);
+}

--- a/src/services/cloud/Party/PartyDb.test.ts
+++ b/src/services/cloud/Party/PartyDb.test.ts
@@ -1,25 +1,45 @@
-import { collection, addDoc, doc, updateDoc } from "firebase/firestore";
-import { Party } from "../../../types/Party";
-import { createPartyInCloud } from "./PartyDb";
+import { collection, addDoc, doc, updateDoc, getDoc } from "firebase/firestore";
+import { 
+    createPartyInCloud, 
+    getPartyFromCloud, 
+    updatePartyDependentDrawFlagInCloud 
+} from "./PartyDb";
+import { gerarPartyCode } from "../../../utils/PartyCode/gerarPartyCode";
 
 jest.mock("firebase/firestore", () => ({
     collection: jest.fn(),
     addDoc: jest.fn(),
     doc: jest.fn(),
     updateDoc: jest.fn(),
+    getDoc: jest.fn(),
     serverTimestamp: jest.fn(() => "mocked-timestamp"),
 }));
 
 jest.mock("../../../config/firebase", () => ({
     db: {},
 }));
-describe("createPartyInCloud", () => {
-    const mockPartyInput: Omit<Party, "id"> = {
+
+jest.mock("../../../utils/PartyCode/gerarPartyCode", () => ({
+    gerarPartyCode: jest.fn(() => "#MOCK123"),
+}));
+
+describe("PartyDb Service", () => {
+    const mockDocId = "mock-generated-party-id";
+    
+    const mockPartyInput = {
         name: "Festa de Fim de Ano",
         event_date: "2026-12-25",
         min_value: 50,
         max_value: 150,
-        invite_code: "#IUHB74",
+        admin_id: "ouefhgaijgnadpspiujfgsu",
+    };
+
+    const expectedPayload = {
+        name: "Festa de Fim de Ano",
+        event_date: "2026-12-25",
+        min_value: 50,
+        max_value: 150,
+        invite_code: "#MOCK123",
         admin_id: "ouefhgaijgnadpspiujfgsu",
         status: "aguardando_sorteio",
         block_dependent_draw: true,
@@ -28,49 +48,93 @@ describe("createPartyInCloud", () => {
         updated_at: "mocked-timestamp",
     };
 
-    const mockDocId = "mock-generated-party-id";
-
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it("deve criar uma party no Firestore com sucesso e retornar o objeto atualizado", async () => {
-        const mockDocRef = { id: mockDocId };
-        (addDoc as jest.Mock).mockResolvedValueOnce(mockDocRef);
-        (updateDoc as jest.Mock).mockResolvedValueOnce(undefined);
-        
-        (collection as jest.Mock).mockReturnValue("mock-collection-ref");
-        (doc as jest.Mock).mockReturnValue("mock-doc-ref");
+    describe("createPartyInCloud", () => {
+        it("deve criar uma party no Firestore com sucesso e retornar o objeto atualizado", async () => {
+            const mockDocRef = { id: mockDocId };
+            (addDoc as jest.Mock).mockResolvedValueOnce(mockDocRef);
+            (updateDoc as jest.Mock).mockResolvedValueOnce(undefined);
+            
+            (collection as jest.Mock).mockReturnValue("mock-collection-ref");
+            (doc as jest.Mock).mockReturnValue("mock-doc-ref");
 
-        const result = await createPartyInCloud(mockPartyInput);
-        
-        expect(collection).toHaveBeenCalledWith(expect.any(Object), "parties");
+            const result = await createPartyInCloud(mockPartyInput);
+            
+            expect(collection).toHaveBeenCalledWith(expect.any(Object), "parties");
+            expect(gerarPartyCode).toHaveBeenCalled();
+            expect(addDoc).toHaveBeenCalledWith("mock-collection-ref", expectedPayload);
+            expect(doc).toHaveBeenCalledWith(expect.any(Object), "parties", mockDocId);
+            expect(updateDoc).toHaveBeenCalledWith("mock-doc-ref", { id: mockDocId });
 
-        expect(addDoc).toHaveBeenCalledWith("mock-collection-ref", {
-            ...mockPartyInput,
-            created_at: "mocked-timestamp",
-            updated_at: "mocked-timestamp",
+            expect(result).toEqual({
+                id: mockDocId,
+                ...expectedPayload,
+            });
         });
 
-        expect(doc).toHaveBeenCalledWith(expect.any(Object), "parties", mockDocId);
+        it("deve propagar o erro caso o addDoc falhe", async () => {
+            (addDoc as jest.Mock).mockRejectedValueOnce(new Error("Erro ao conectar com o Firestore"));
 
-        expect(updateDoc).toHaveBeenCalledWith("mock-doc-ref", {
-            id: mockDocId,
-        });
-
-        expect(result).toEqual({
-            id: mockDocId,
-            ...mockPartyInput,
-            created_at: "mocked-timestamp",
-            updated_at: "mocked-timestamp",
+            await expect(createPartyInCloud(mockPartyInput)).rejects.toThrow("Erro ao conectar com o Firestore");
+            
+            expect(updateDoc).not.toHaveBeenCalled();
         });
     });
 
-    it("deve propagar o erro caso o addDoc falhe", async () => {
-        (addDoc as jest.Mock).mockRejectedValueOnce(new Error("Erro ao conectar com o Firestore"));
+    describe("getPartyFromCloud", () => {
+        it("deve retornar os dados da party corretamente se o documento existir", async () => {
+            (doc as jest.Mock).mockReturnValue("mock-doc-ref");
+            
+            const mockSnapshot = {
+                exists: () => true,
+                id: mockDocId,
+                data: () => ({
+                    name: "Festa de Fim de Ano",
+                    status: "aguardando_sorteio"
+                })
+            };
+            (getDoc as jest.Mock).mockResolvedValueOnce(mockSnapshot);
 
-        await expect(createPartyInCloud(mockPartyInput)).rejects.toThrow("Erro ao conectar com o Firestore");
-        
-        expect(updateDoc).not.toHaveBeenCalled();
+            const result = await getPartyFromCloud(mockDocId);
+
+            expect(doc).toHaveBeenCalledWith(expect.any(Object), "parties", mockDocId);
+            expect(getDoc).toHaveBeenCalledWith("mock-doc-ref");
+            expect(result).toEqual({
+                id: mockDocId,
+                name: "Festa de Fim de Ano",
+                status: "aguardando_sorteio"
+            });
+        });
+
+        it("deve retornar null se o documento não existir", async () => {
+            (doc as jest.Mock).mockReturnValue("mock-doc-ref");
+            
+            const mockSnapshot = {
+                exists: () => false
+            };
+            (getDoc as jest.Mock).mockResolvedValueOnce(mockSnapshot);
+
+            const result = await getPartyFromCloud("id-inexistente");
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe("updatePartyDependentDrawFlagInCloud", () => {
+        it("deve atualizar a flag block_dependent_draw e o timestamp de update", async () => {
+            (doc as jest.Mock).mockReturnValue("mock-doc-ref");
+            (updateDoc as jest.Mock).mockResolvedValueOnce(undefined);
+
+            await updatePartyDependentDrawFlagInCloud(mockDocId, false);
+
+            expect(doc).toHaveBeenCalledWith(expect.any(Object), "parties", mockDocId);
+            expect(updateDoc).toHaveBeenCalledWith("mock-doc-ref", {
+                block_dependent_draw: false,
+                updated_at: "mocked-timestamp",
+            });
+        });
     });
 });

--- a/src/services/cloud/Party/PartyDb.ts
+++ b/src/services/cloud/Party/PartyDb.ts
@@ -4,11 +4,14 @@ import {
     serverTimestamp,
     doc,
     updateDoc,
+    getDoc,
 } from "firebase/firestore";
 import { Party } from "../../../types/Party";
 import { db } from '../../../config/firebase';
+import { PartyCreationDTO } from "../../../dto/Party/PartyCreationDTO";
+import { gerarPartyCode } from "../../../utils/PartyCode/gerarPartyCode";
 
-export async function createPartyInCloud(party: Omit<Party, "id">) {
+export async function createPartyInCloud(party: PartyCreationDTO) {
     const partiesRef = collection(db, "parties");
 
     const payload = {
@@ -16,11 +19,11 @@ export async function createPartyInCloud(party: Omit<Party, "id">) {
         event_date: party.event_date,
         min_value: party.min_value,
         max_value: party.max_value,
-        invite_code: party.invite_code,
+        invite_code: gerarPartyCode(),
         admin_id: party.admin_id,
-        status: party.status,
-        block_dependent_draw: party.block_dependent_draw,
-        allow_wishlist_changes_after_draw: party.allow_wishlist_changes_after_draw,
+        status: "aguardando_sorteio",
+        block_dependent_draw: true,
+        allow_wishlist_changes_after_draw: false,
         created_at: serverTimestamp(),
         updated_at: serverTimestamp(),
     };
@@ -35,4 +38,27 @@ export async function createPartyInCloud(party: Omit<Party, "id">) {
         id: docRef.id,
         ...payload,
     };
+}
+
+export async function getPartyFromCloud(partyId: string): Promise<Party | null> {
+    const partyDocRef = doc(db, "parties", partyId);
+    const partySnapshot = await getDoc(partyDocRef);
+
+    if (partySnapshot.exists()) {
+        const data = partySnapshot.data();
+        return {
+            id: partySnapshot.id,
+            ...data,
+        } as Party;
+    }
+
+    return null;
+}
+
+export async function updatePartyDependentDrawFlagInCloud(partyId: string, blockDependentDraw: boolean) {
+    const partyDocRef = doc(db, "parties", partyId);
+    await updateDoc(partyDocRef, {
+        block_dependent_draw: blockDependentDraw,
+        updated_at: serverTimestamp(),
+    });
 }


### PR DESCRIPTION
### O que foi implementado?

**Novos DTOs:** `DrawRestrictionCreationDTO` para criação de restrição de sorteio, `DrawRestrictionResponseDTO` para busca de restrição de sorteio e `PartyCreationDTO` para criação de party.
**Novo service `DrawRestrictionDb`:** tem as funções `getDrawRestrictionsByPartyFromCloud` que busca todas as restrições de sorteio de uma party, `createDrawRestrictionInCloud` que salva uma restrição de sorteio no banco de dados, e `deleteDrawRestrictionFromCloud` que deleta uma restrição de sorteio do banco de dados.
**Alterações na função `createPartyInCloud` do `PartyDb`:** agora usa `PartyCreationDTO` e `invite_code` é gerado durante a criação da party.
**Nova função `getPartyFromCloud` em `PartyDb`:** busca uma party por id.
**Nova função `updatePartyDependentDrawFlagInCloud` em `PartyDb`:** atualiza uma alteração na flag `block_dependent_draw` de uma party.
**Alterações em `PartyDrawRestrictionsViewModel`:** agora chama as funções `getPartyFromCloud`, `updatePartyDependentDrawFlagInCloud`, `getDrawRestrictionsByPartyFromCloud`, `createDrawRestrictionInCloud` e `deleteDrawRestrictionFromCloud` (ou seja, agora usa o banco de dados ao invés de mock).
**Alteração em `PartyAdminViewModel`:** agora recebe id da party por route ao invés de nome e código de convite.
**Alteração em `CreatePartyViewModel`:** agora usa o `PartyCreationDTO`.

### Checklist de Qualidade
- [x] Clean Code: variáveis e funções têm nomes significativos?
- [x] Responsabilidade Única: funções/componentes fazem apenas uma coisa?
- [x] Testes Unitários: a lógica (TS) foi testada e passou?
- [x] Testes Funcionais: a interface (React Native) funciona como o esperado?
- [x] Sem Código Morto: comentários desnecessários ou "lixo" removidos?

### Prova de Funcionamento

Criação de restrições entre duas pessoas (_one way_ e _both ways_):
<img width="1451" height="845" alt="image" src="https://github.com/user-attachments/assets/3744090c-1f22-4455-9f80-ee8623b50847" />
<img width="1456" height="844" alt="image" src="https://github.com/user-attachments/assets/92e2c20b-0434-4a68-a938-11fa792fd01a" />

Atualização da flag `block_dependent_draw`:
<img width="1448" height="847" alt="image" src="https://github.com/user-attachments/assets/3ace386d-da06-447a-8386-ab10a8031d0d" />
<img width="1449" height="843" alt="image" src="https://github.com/user-attachments/assets/ca74828e-b859-4925-815c-f2f3bd4e704d" />

